### PR TITLE
Update module.py

### DIFF
--- a/patch_conv/module.py
+++ b/patch_conv/module.py
@@ -2,7 +2,6 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 
-
 class PatchConv2d(nn.Module):
     def __init__(self, splits: int = 4, conv2d: nn.Conv2d = None, *args, **kwargs):
         super(PatchConv2d, self).__init__()
@@ -17,22 +16,25 @@ class PatchConv2d(nn.Module):
         b, c, h, w = x.shape
         if c * h * w >= (1 << 30):
             assert h % self.splits == 0
-            x_permuted = x.view(b, c, self.splits, h // self.splits, w).permute(0, 2, 1, 3, 4)
-            x_padded = F.pad(
-                x_permuted,
-                (0, 0, self.conv2d.padding[0], self.conv2d.padding[0]),
-                mode="constant" if self.conv2d.padding_mode == "zeros" else self.conv2d.padding_mode,
-                value=0,
-            )
-            x_padded[:, 1:, :, : self.conv2d.padding[0]] = x_permuted[:, :-1, :, -self.conv2d.padding[0] :]
-            x_padded[:, :-1, :, -self.conv2d.padding[0] :] = x_permuted[:, 1:, :, : self.conv2d.padding[0]]
-            x_padded = x_padded.view(b * self.splits, c, -1, w)
+            split_size = h // self.splits
+            x_permuted = x.view(b, c, self.splits, split_size, w).permute(0, 2, 1, 3, 4)
             padding_bak = self.conv2d.padding
             self.conv2d.padding = (0, self.conv2d.padding[1])
-            output = self.conv2d(x_padded, *args, **kwargs)
+            output = torch.zeros(b, self.splits, self.conv2d.out_channels, split_size + 2 * self.conv2d.padding[0], w, device=x.device)
+            for i in range(self.splits):
+                if i == 0:
+                    x_padded = F.pad(
+                        x_permuted[:, i],
+                        (0, 0, self.conv2d.padding[0], self.conv2d.padding[0]),
+                        mode="constant" if self.conv2d.padding_mode == "zeros" else self.conv2d.padding_mode,
+                        value=0,
+                    )
+                else:
+                    x_padded[:, :, : self.conv2d.padding[0]] = output[:, i - 1, :, -2 * self.conv2d.padding[0] : -self.conv2d.padding[0]]
+                    x_padded[:, :, -self.conv2d.padding[0] :] = x_permuted[:, i, :, : self.conv2d.padding[0]]
+                output[:, i] = self.conv2d(x_padded, *args, **kwargs)
             self.conv2d.padding = padding_bak
-            _, oc, oh, ow = output.shape
-            output = output.view(b, self.splits, oc, oh, ow).permute(0, 2, 1, 3, 4).reshape(b, oc, -1, ow)
+            output = output.permute(0, 2, 1, 3, 4).reshape(b, self.conv2d.out_channels, -1, w)
             return output
         else:
             return self.conv2d(x, *args, **kwargs)


### PR DESCRIPTION
The main improvements in this version are:

Instead of using F.pad and updating x_padded for each split, the code pre-allocates the output tensor output and directly updates it with the padded values from the previous split. This avoids the need to store the entire padded input tensor in memory.
The code uses a loop to process each split separately, which allows for more efficient memory usage. The padded input tensor x_padded is created only for the first split, and subsequent splits reuse the output from the previous split for padding.
The torch.zeros function is used to pre-allocate the output tensor output on the same device as the input tensor x. This avoids the need for additional memory allocation during the loop.

These optimizations further reduce the memory footprint of the PatchConv2d module by avoiding the storage of the entire padded input tensor and reusing the output from previous splits for padding.
Please note that these optimizations assume that the height dimension of the input tensor is divisible by the number of splits (self.splits). If this assumption is not met, the code will raise an assertion error.